### PR TITLE
INFRA-5596 add emit_umatched_lines

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -2,6 +2,7 @@
   @type pipe
   path /log/php-error.log
   multiline_flush_interval 2s
+  emit_unmatched_lines true
   format multiline
   format_firstline /^\[\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2}:\d{2}\s\w+\/\w+\]/
   format1 /^\[(?<time>\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2}:\d{2}\s\w+\/\w+)\] PHP (?<severity>[^:]+):\s?+(?<msg>.*)/
@@ -13,6 +14,7 @@
   @type pipe
   path /log/fpm-error.log
   multiline_flush_interval 2s
+  emit_unmatched_lines true
   format multiline
   format_firstline /^\[\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2}:\d{2}(.?\d+)?\]/
   format1 /^\[(?<timestamp>\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2}:\d{2}(.?\d+)?\]) (?<msg>.*)/
@@ -24,6 +26,7 @@
   @type pipe
   path /log/slow.log
   multiline_flush_interval 2s
+  emit_unmatched_lines true
   format multiline
   format_firstline /^\[\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2}:\d{2}\]/
   format1 /^\[(?<time>\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2}:\d{2})\]\s+\[pool\s+(?<pool>\w+)\]\s+pid\s+(?<pid>\d+)\s?(?<msg>.*)/

--- a/plugins/in_namedpipe.rb
+++ b/plugins/in_namedpipe.rb
@@ -24,6 +24,7 @@ module Fluent
         config_param :tag , :string
         desc 'The interval of flushing the buffer for multiline format'
         config_param :multiline_flush_interval, :time, default: nil
+        config_param :emit_unmatched_lines, :bool, default: false
         #TODO: Not use yet
         config_param :receive_interval, :time, :default => 1
 


### PR DESCRIPTION
Added `emit_unmatched_lines` parameter which should print lines even when it is not parsed properly. 
There will be new tag: `unmatched_line` inside the message, which will include unparsed messages, to clearly distinguish between parsed and not parsed messages. 